### PR TITLE
Require entire rack library as outlined in documentation

### DIFF
--- a/lib/rack/charset.rb
+++ b/lib/rack/charset.rb
@@ -1,5 +1,5 @@
 require "rack/charset/version"
-require "rack/response"
+require "rack"
 module Rack
   class Charset
 


### PR DESCRIPTION
According to the Rack documentation, https://github.com/rack/rack#label-Usage, we should be requiring the entire rack library to avoid any unexpected behaviour. 

Currently rack-charset only requires `rack/response`, while specific, causes the following errors: 

```
% gem install rack-charset
Fetching rack-charset-1.0.0.gem
Successfully installed rack-charset-1.0.0
Parsing documentation for rack-charset-1.0.0
Installing ri documentation for rack-charset-1.0.0
Done installing documentation for rack-charset after 0 seconds
1 gem installed
% irb
>> require 'rack/charset'
Traceback (most recent call last):
        7: from rack-charset-1.0.0/lib/rack/charset.rb:2:in `<top (required)>'
        3: from /Users/tom/.gem/ruby/2.7.2/gems/rack-2.2.3/lib/rack/response.rb:5:in `<top (required)>'
        2: from /Users/tom/.gem/ruby/2.7.2/gems/rack-2.2.3/lib/rack/response.rb:18:in `<module:Rack>'
        1: from /Users/tom/.gem/ruby/2.7.2/gems/rack-2.2.3/lib/rack/response.rb:24:in `<class:Response>'
NameError (uninitialized constant Rack::Response::Utils)
```

This change will fix the error. 